### PR TITLE
chore: update .gitignore to exclude VS Code files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# IDE 
+.vscode/


### PR DESCRIPTION
This update to the .gitignore file excludes the .vscode folder, which contains local configurations specific to VS Code.